### PR TITLE
feat: added multiple target frameworks support

### DIFF
--- a/src/SImpl.NanoContainer/SImpl.NanoContainer.csproj
+++ b/src/SImpl.NanoContainer/SImpl.NanoContainer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;net6.0;net7.0;netstandard2.1;</TargetFrameworks>
     <Title>SImpl.NanoContainer</Title>
     <Authors>Mikkel Keller</Authors>
     <Description>SImpl.NanoContainer</Description>


### PR DESCRIPTION
Added support for multiple target frameworks: `net5.0, net6.0, net7.0, netstandard2.1`.

It will allow publishing at once multiple NuGet supported dotnet versions.
It will also require CI/CD adjustments:
 * install SDKs
 * build process to run the command: `dotnet build -f net5.0` (`net5.0, net6.0, net7.0, netstandard2.1`)
 * restore process to run the command:  `dotnet publish -f net5.0`.

Build results:

 * `net7.0`

![image](https://user-images.githubusercontent.com/29370044/193396098-e5c0ee7a-13d8-452c-ad26-14d167c3fc59.png)

 * `net6.0`

![image](https://user-images.githubusercontent.com/29370044/193396113-7d82ac8b-5656-4bcb-80fd-029038ad5e24.png)


 * `net5.0`

![image](https://user-images.githubusercontent.com/29370044/193396130-73e5c3e3-615e-4bbd-a00d-eda9c09e1b6a.png)


 * `netstandard2.1`

![image](https://user-images.githubusercontent.com/29370044/193396142-cf68b4d2-a91c-45f5-b852-f30aaf994668.png)


PS: if you could annotate this PR with `hacktoberfest-accepted` label after successful review? More details: https://hacktoberfest.com/participation/#maintainers

cc: @K3llr 

![image](https://user-images.githubusercontent.com/29370044/193396276-ed6ca53f-a160-4021-8ed5-a7435f54beb0.png)

